### PR TITLE
Remove 'U' option for file opening

### DIFF
--- a/Anki 2.1.45-/latexbiport/lateximport.py
+++ b/Anki 2.1.45-/latexbiport/lateximport.py
@@ -66,7 +66,7 @@ class LatexImporter(NoteImporter):
     def openFile(self):
         # modified from TextImporter (csvfile.py)
         self.dialect = None
-        self.fileobj = open(self.file, "rbU")
+        self.fileobj = open(self.file, "rb")
         self.processFile(str(self.fileobj.read(), "utf-8"))
 
     def foreignNotes(self):


### PR DESCRIPTION
The 'U' option is no longer present in newer python versions, which leads to an error.