### PR TITLE
Update exporter to use new anki exporting module

### DIFF
--- a/Anki 24.04.1/latexbiport/Readme.txt
+++ b/Anki 24.04.1/latexbiport/Readme.txt
@@ -1,0 +1,52 @@
+Class hierarchy (see anki/importing):
+-------------------------------------
+
+ForeignNote  (noteimp.py)
+
+Importer     (base.py)
+ |
+ |
+NoteImporter (noteimp.py)
+- def: run(self)
+       self.importNotes(self.foreignNotes)
+- def: importNotes(self, notes)
+       ... heart of the importing machinary ...
+ |                              |
+ |                              |
+TextImporter (csvfile.py)      LatexImporter  (lateximport.py)
+- openFile(self)               - openFile(self)
+- foreignNotes(self)           - foreignNotes(self)
+
+
+As indicated, the class LatexImporter is derived from the class NoteImporter. 
+Much of its code is copied verbatim from TextImporter.  However, the methods 
+openFile(self) and foreignNotes(self) have been severely modified.
+ 
+
+Code executing order at run-time (see aqt/importing.py):
+-------------------------------------------------------
+
+    . openFile() is called as soon as the user has chosen a file to import.
+      In more detail, we have the following call order:
+      onImport() --calls--> importFile(file)
+                 --calls--> importer = importer(.., file)
+                            importer.open()
+		 --calls--> importer.cacheFile()
+		 --calls--> importer.openFile()
+
+    . Then the ImportDialog (aqt/importing.py) is shown, 
+      in which the user may specify which deck to import into etc.
+	
+    . When the user clicks "Import":
+      doImport() --calls--> (Note)importer.run()
+                 --calls--> (Text|Latex|..)importer.foreignNotes()
+
+In TextImporter, openFile() only checks that the file format is understood.
+No further processing of the file takes place at this stage.
+
+In LatexImporter, openFilen() already does all the processing required,
+because it needs to work out the maximum number of fields of the notes
+to be imported.
+foreignNotes() later only returns a ready-made list of foreignNote's.
+
+

--- a/Anki 24.04.1/latexbiport/__init__.py
+++ b/Anki 24.04.1/latexbiport/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import lateximport
+from . import latexexport

--- a/Anki 24.04.1/latexbiport/latexexport.py
+++ b/Anki 24.04.1/latexbiport/latexexport.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+import re
+import aqt
+import aqt.main
+import anki
+import anki.collection
+from aqt.qt import *
+from aqt import gui_hooks
+from aqt.operations import QueryOp
+from aqt.import_export.exporting import Exporter, ExportOptions, export_progress_update
+from aqt.utils import tooltip, tr
+from anki.utils import split_fields
+from anki.collection import (
+    ExportLimit,
+    DeckIdLimit,
+    NoteIdsLimit,
+)
+
+
+class LatexNoteExporter(Exporter):
+    extension = "tex"
+    show_deck_list = True
+    show_include_tags = True
+    show_include_guid = True
+
+    @staticmethod
+    def name() -> str:
+        return "Notes in Latex"
+
+    def export(self, mw: aqt.main.AnkiQt, options: ExportOptions) -> None:
+        options = gui_hooks.exporter_will_export(options, self)
+
+        def on_success(count: int) -> None:
+            gui_hooks.exporter_did_export(options, self)
+            tooltip(tr.exporting_card_exported(count=self.count), parent=mw)
+
+        QueryOp(
+            parent=mw,
+            op=lambda col: self.export_note_latex(
+                mw=mw,
+                col=col,
+                out_path=options.out_path,
+                options=options,
+            ),
+            success=on_success,
+        ).with_backend_progress(export_progress_update).run_in_background()
+
+    def export_note_latex(
+        self,
+        mw: aqt.main.AnkiQt,
+        col: anki.collection.Collection,
+        out_path: str,
+        options: ExportOptions,
+    ) -> None:
+        notes = []
+        TAB = "    "
+
+        for guid, note_id, flds, tags, notetype_id in col.db.execute(
+            self.db_query(options.limit)
+        ):
+            note_lines = []
+            model = col.models.get(notetype_id)
+
+            note_lines.append(r"\begin{note}")
+            # Currently only exports note_id as unique identifier instead of guid as it 
+            # contains special characters which lead to problems in latex even when escaped
+            if options.include_guid:
+                note_lines.append("\\xplain{" + self.escape_latex_chars(str(note_id)) + "}")
+
+            for field in split_fields(flds):
+                field = self.replace_line_breaks(field)
+
+                if field.find("[latex]") != -1:
+                    # Treat as latex field
+                    field = self.convert_html_to_latex(field)
+                    # Export field as xfield if it consists of a single line
+                    if field.find("\n") == -1:
+                        note_lines.append(TAB + r"\xfield{" + field + "}")
+                    else:
+                        field = self.strip_new_lines(field)
+                        field = TAB + TAB + field.replace("\n", "\n" + TAB + TAB)
+                        note_lines.append(
+                            TAB
+                            + r"\begin{field}"
+                            + "\n"
+                            + field
+                            + "\n"
+                            + TAB
+                            + r"\end{field}"
+                        )
+                else:
+                    # Treat as plain-text field
+                    # Export field as xplain field if it consists of a single line
+                    if field.find("\n") == -1:
+                        note_lines.append(TAB + r"\xplain{" + field + "}")
+                    else:
+                        field = self.convert_html_to_latex(field)
+                        field = self.strip_new_lines(field)
+                        field = TAB + TAB + field.replace("\n", "\n" + TAB + TAB)
+                        note_lines.append(
+                            TAB
+                            + r"\begin{plain}"
+                            + "\n"
+                            + field
+                            + "\n"
+                            + TAB
+                            + r"\end{plain}"
+                        )
+            # Remove empty fields at the end of the note:
+            while note_lines[-1] == TAB + r"\xplain{}":
+                note_lines.pop()
+            # Tags
+            if options.include_tags:
+                cleantag = tags.strip()
+                if cleantag != "":
+                    note_lines.append(TAB + r"\tags{" + tags.strip() + r"}")
+
+            note_lines.append(r"\end{note}" + "\n")
+            notes.append("\n".join(note_lines))
+        self.count = len(notes)
+        out = (
+            "% -*- coding: utf-8 -*-\n"
+            + model["latexPre"]
+            + "\n"
+            + "\n".join(notes)
+            + "\n"
+            + model["latexPost"]
+        )
+        with open(out_path, mode="w", encoding="utf-8") as file:
+            file.write(out)
+
+    def db_query(self, limit: ExportLimit) -> str:
+        """Request the notes to be exported from the database by
+        deck id or noteid
+        """
+
+        if type(limit) == DeckIdLimit:
+            query = (
+                "SELECT n.guid, n.id, n.flds, n.tags, n.mid "
+                "FROM notes n JOIN cards c ON n.id = c.nid "
+                "WHERE c.did IN "
+                "(SELECT id FROM decks "
+                "WHERE name LIKE ("
+                f"SELECT name FROM decks WHERE id={limit.deck_id}) || '%')"
+            )
+        elif type(limit) == NoteIdsLimit:
+            query = (
+                "SELECT n.guid, n.id, n.flds, n.tags, n.mid "
+                "FROM notes n JOIN cards c ON n.id = c.nid "
+                f"WHERE n.id IN {tuple(limit.note_ids)}"
+            )
+        else:
+            raise Exception(f"ExportLimit does neither have type DeckIdLimit nor NoteIdsLimit")
+        return query
+
+    def replace_line_breaks(self, text: str) -> str:
+        """Replace html-line breaks by plain-text line breaks"""
+        # Remove plain-text line breaks
+        text = text.replace("\n", "")
+        # Convert some html
+        htmldict = {
+            r"<br>": "\n",
+            r"<br />": "\n",
+            r"<div>": "\n",
+            r"</div>": "",
+            r"&nbsp;": r" ",
+        }
+        for k, v in htmldict.items():
+            text = text.replace(k, v)
+        return text
+
+    def strip_new_lines(self, text: str) -> str:
+        """Remove newlines at beginning and end of text and
+        replace double blank lines by single blank lines
+        """
+        text = re.sub("\n\s*\n+", "\n\n", text).strip()
+        return text
+
+    def escape_latex_chars(self, text: str) -> str:
+        """Escapes all special and command chars in string"""
+        text = re.sub(r"([#$%^&_}{~])", r"\\\1", text)
+        return text
+
+    def convert_html_to_latex(self, text: str) -> str:
+        """Replaces certain html characters and converts html tags
+        to their latex equivalents
+        """
+        # Replace html specifc characters
+        htmldict = {r"&amp;": r"&", r"&lt;": r"<", r"&gt;": r">"}
+        for k, v in htmldict.items():
+            text = text.replace(k, v)
+        # Remove latex marks and any surrounding line breaks
+        text = re.sub("\n*\[latex\]", "", text)
+        text = re.sub("\[/latex\]\n*", "", text)
+        # Replace <ul>
+        text = re.sub(r"<ul.*?>", r"\\begin{itemize}\n", text)
+        text = re.sub(r"</ul>", r"\\end{itemize}", text)
+        # Replace <ol>
+        text = re.sub(r"<ol.*?>", r"\\begin{enumerate}\n", text)
+        text = re.sub(r"</ol>", r"\\end{enumerate}", text)
+        # Replace <li>
+        text = re.sub(r"<li.*?>", r"\\item ", text)
+        text = re.sub(r"</li>", r"\n", text)
+        # Replace bold text to latex bold
+        text = re.sub(r"<b>(.*?)</b>", r"\\textbf{\1}", text)
+        # Convert italic to latex italic
+        text = re.sub(r"<i>(.*?)</i>", r"\\textit{\1}", text)
+        # Replace <i> underline
+        text = re.sub(r"<u>(.*?)</u>", r"\\underline{\1}", text)
+        # Replace <sub> subscript
+        text = re.sub(r"<sub>(.*?)</sub>", r"\\textsubscript{\1}", text)
+        # Replace <sup> superscript
+        text = re.sub(r"<sup>(.*?)</sup>", r"\\textsuperscript{\1}", text)
+        # Fix Double Newline
+        text = re.sub(r"\n\s*\n+", "\n", text)
+        # Remove any remaining html tags
+        text = re.sub("<[^<]+?>", "", text)
+        return text
+
+
+def addExporterToList(exporters_list) -> None:
+    exporters_list.append(LatexNoteExporter)
+
+
+gui_hooks.exporters_list_did_initialize.append(addExporterToList)

--- a/Anki 24.04.1/latexbiport/lateximport.py
+++ b/Anki 24.04.1/latexbiport/lateximport.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+# import the "show info" tool from utils.py
+from aqt.utils import showInfo
+
+import anki.importing as importing
+from anki.importing.noteimp import ForeignNote
+from anki.importing.noteimp import NoteImporter
+import operator
+import re
+
+from aqt import mw
+from aqt.qt import *
+from aqt.importing import ImportDialog
+from anki.hooks import wrap
+
+
+# GUI:
+def hideAllowHTML(self):
+    if type(self.importer) == LatexImporter:
+        self.frm.allowHTML.hide()
+ImportDialog.setupMappingFrame = wrap(ImportDialog.setupMappingFrame, hideAllowHTML)
+
+
+# MEAT:
+class LatexImporter(NoteImporter):
+    
+    needMapper = True
+    needDelimiter = False
+    # allowHTML always True (assignments have no affect):
+    allowHTML = property(lambda self: True, lambda self,value: 0, lambda self: 0, "allowHTML, always returns True")
+  
+    def __init__(self, *args):
+        # excerpt from TextImporter (csvfile.py)
+        NoteImporter.__init__(self, *args)
+        self.fileobj = None
+        # preamble and postamble are saved in the following variables,
+        # but they are not actually processed by the current version
+        # of LatexImporter:
+        self.preamble = ""
+        self.postamble = ""
+        # noteList will contain all ForeignNotes that have been imported:
+        self.noteList = []
+        # the log will be built from a list of warnings and a list
+        # of text passages that have been ignored
+        self.log = []
+        self.rubbishList = []
+        self.warningList = []
+    
+    def fields(self):
+        # exact copy from TextImporter (csvfile.py)
+        "Number of fields."
+        self.open()
+        return self.numFields
+    
+    def open(self):
+        # exact copy from TextImporter (csvfile.py)
+        "Parse the top line and determine the pattern and number of fields."
+        self.cacheFile()
+
+    def cacheFile(self):
+        # exact copy from TextImporter (csvfile.py)
+        "Read file into self.lines if not already there."
+        if not self.fileobj:
+            self.openFile()
+    
+    def openFile(self):
+        # modified from TextImporter (csvfile.py)
+        self.dialect = None
+        self.fileobj = open(self.file, "rb")
+        self.processFile(str(self.fileobj.read(), "utf-8"))
+
+    def foreignNotes(self):
+        # modified from TextImporter (csvfile.py)
+        return self.noteList
+
+    def textToHtml(self, text):
+        "Replace line breaks, <, > and & by HTML equivalents"
+        htmldict = [[r"&", r"&amp;"],
+                    [r"<", r"&lt;"],
+                    [r">", r"&gt;"]]
+        for v in htmldict:
+            text = text.replace(v[0], v[1])
+        # order of replacements matters --
+        # line breaks need to be replaced last!
+        text = text.replace("\n", r"<br>")
+        return text
+
+    def ignore(self, value, ignored):
+        if re.search("\S", value) != None:
+            ignored.append(value.strip())
+
+    # parsing functions for different parts of the latex document
+    # 1. parsing functions for different field types/tags
+    def process_plain(self, value, note):
+        value = self.textToHtml(value)
+        note.fields.append(value)
+
+    def process_latex(self, value, note):
+        value = value.strip()
+        if value != "":
+            value = r"[latex]" + value + r"[/latex]"
+        value = self.textToHtml(value)
+        note.fields.append(value)
+
+    def process_tags(self, value, note):
+        note.tags.extend(value.split())
+
+    # Klammer-zu-suche:
+    def findClosingBrace(self, string):
+        "return position of } matching invisible { at beginning of string"
+        l = 1  # parenthization level
+        p = 0
+        while p < len(string) and l > 0:
+            if string[p] == "\\":
+                p += 1  # skip a character
+            elif string[p] == "{":
+                l += 1
+            elif string[p] == "}":
+                l -= 1
+            elif string[p] == "%":
+                jump = string[p:].find("\n")  # jump to end of line
+                if jump == -1: break
+                else: p += jump
+            p += 1  # loop
+        if l == 0:  # matching "}" found
+            return (p-1, p)
+        else:
+            self.warningList.append("\nWARNING: } expected at the end of the following string.\n")
+            self.warningList.append(string + "\n")
+            return None
+
+    def findCommand(self, string, command, arg=None, warning=False):
+        if arg == None:
+            pattern = r"\\" + command + r"(?![a-z])"
+        elif arg == "?":
+            pattern = r"\\" + command + r"\s*{"
+        else:
+            pattern = r"\\" + command + r"\s*{" + arg + r"}"
+        p = 0
+        mo = None
+        while p < len(string):
+            mo = re.match(pattern, string[p:])
+            if mo: break
+            if string[p] == "\\":
+                p += 1  # skip a character
+            elif string[p] == "%":
+                jump = string[p:].find("\n")  # jump to end of line
+                if jump == -1: break
+                else: p += jump
+            p += 1  # loop
+        if mo:
+            return (p + mo.start(), p + mo.end())
+        else:
+            if warning == True:
+                self.warningList.append("\nWARNING: The environment containing the following string seems to be corrupted.\n")
+                self.warningList.append(string + "\n")
+            return None
+
+    def findIter(self, string, findfun):
+        poslist = []
+        pos = (0, 0)
+        while True:
+            adpos = findfun(string[pos[1]:])
+            if adpos == None:
+                break
+            if adpos[1] == adpos[0]:
+                # This really shouldn't happen, I just want to make sure
+                # I don't land in an infinite loop
+                self.warningList.append("\nERROR: An error occurred while parsing the following string. Import may have failed.\n")
+                self.warningList.append(string + "\n")
+                break
+            pos = (pos[1] + adpos[0], pos[1] + adpos[1])
+            poslist.append(pos)
+        return poslist
+
+    def cutIntoPieces(self, string, cList):
+        """returns a list of the strings before and in between all sections
+        marked by the commands in cList, and a list of all sections"""
+        triples = [(ao[0], ao[1], cList.index(command))
+                   for command in cList
+                   for ao in self.findIter(string, command['beginfun'])]
+        triples.sort()
+        Begins = [p[0] for p in triples] + [len(string)]
+        intBegins = [p[1] for p in triples]
+        commandIndices = [p[2] for p in triples]
+
+        returnList = []
+        i, prevEnd = 0, 0
+        while i < len(intBegins):
+            ci = commandIndices[i]
+            preString = string[prevEnd:Begins[i]]
+            intString = string[intBegins[i]:Begins[i+1]]
+            ends = cList[ci]['endfun'](intString)
+            if ends == None:
+                valueString = intString
+                prevEnd = Begins[i+1]
+            else:
+                valueString = intString[:ends[0]]
+                prevEnd = intBegins[i] + ends[1]
+            returnList.append((preString, valueString, ci))
+            i += 1
+        return returnList, string[prevEnd:]
+
+    def processFile(self, fileString):
+        docCommands = [{'beginfun': lambda string: self.findCommand(string, r"begin", r"document"),
+                        'endfun': lambda string: self.findCommand(string, r"end", r"document", warning=True),
+                        'process': lambda string: self.processDocument(string)}]
+        pieces, post = self.cutIntoPieces(fileString, docCommands)
+        # may return several documents if file was written like that,
+        # but I'll ignore all except the first,
+        # just like any latex interpreter would
+        if pieces:
+            self.preamble, document, ci = pieces[0]
+        else:
+            self.log = ["\nWARNING: Unable to determine document environment. Interpreted the whole file as document environment instead.\n"]
+            self.preamble = ""
+            document = fileString
+            ci = 0  # unsure about this line; added [2021-02-27] as a hotfix without understanding what ci is
+        self.preamble = self.preamble + "\\begin{document}"
+        self.postamble = "\\end{document}" + post
+        self.processDocument(document)
+        # make all notes same length and
+        # add tags as extra field at the very end
+        # (Adding tags as field is necessary for tags to be "update-able":
+        #  when updating a note via import, the core ANKI importer
+        #  does not check whether tags have changed unless they are
+        #  imported as an additional field.)
+        self.numFields = max([len(note.fields) for note in self.noteList]) + 1
+        # (+1 for tag-field)
+        for note in self.noteList:
+            note.fields = note.fields + [""]*(self.numFields-1-len(note.fields)) + [" ".join(note.tags)]
+            note.tags = []
+        # clean up rubbishList & provide feedback
+        self.rubbishList = [s.strip() for s in self.rubbishList if re.search("\S", s) != None]
+        self.log = self.log + self.warningList
+        if len(self.rubbishList) > 0:
+                self.log = self.log + [str(len(self.rubbishList)) + " lines have been ignored – they occurred in between notes or in between fields.\n"]
+
+    def processDocument(self, document):
+        globalTags = []
+        noteCommands = [{'beginfun': lambda string: self.findCommand(string, r"begin", r"note"),
+                         'endfun': lambda string: self.findCommand(string, r"end", r"note", warning=True),
+                         'process': lambda string: self.processNote(string, globalTags)}]
+        pieces, post = self.cutIntoPieces(document, noteCommands)
+        for pre, value, ci in pieces:
+            globalTags = self.processInterNoteText(pre, globalTags)
+            noteCommands[ci]['process'](value)
+             
+    def processNote(self, noteString, globalTags):
+        newNote = ForeignNote()
+        newNote.tags.extend(globalTags)
+        fieldCommands = [{'beginfun': lambda string: self.findCommand(string, r"field"),
+                          'endfun': lambda string: self.findCommand(string, r"endfield"),
+                          'process': lambda string: self.processLatexField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"begin", r"field"),
+                          'endfun': lambda string: self.findCommand(string, r"end", r"field", warning=True),
+                          'process': lambda string: self.processLatexField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"xfield", r"?"),
+                          'endfun': self.findClosingBrace,
+                          'process': lambda string: self.processLatexField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"plain"),
+                          'endfun': lambda string: self.findCommand(string, r"endplain"),
+                          'process': lambda string: self.processPlainField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"begin", r"plain"),
+                          'endfun': lambda string: self.findCommand(string, r"end", r"plain", warning=True),
+                          'process': lambda string: self.processPlainField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"xplain", r"?"),
+                          'endfun': self.findClosingBrace,
+                          'process': lambda string: self.processPlainField(string, newNote)},
+                         {'beginfun': lambda string: self.findCommand(string, r"tags", r"?"),
+                          'endfun': self.findClosingBrace,
+                          'process': lambda string: self.processTags(string, newNote)}
+                         ]
+        pieces, post = self.cutIntoPieces(noteString, fieldCommands)
+        for pre, value, ci in pieces:
+            self.rubbishList.append(pre)
+            fieldCommands[ci]['process'](value)
+        self.rubbishList.append(post)
+        self.noteList.append(newNote)
+
+    def processInterNoteText(self, string, globalTags):
+        tagCommands = [{'beginfun': lambda string: self.findCommand(string, r"tags", "?"),
+                        'endfun': self.findClosingBrace,
+                        'process': None}
+                       ]
+        pieces, post = self.cutIntoPieces(string, tagCommands)
+        self.rubbishList.extend([pre for pre, value, ci in pieces] + [post])
+        tags = [tag for pre, value, ci in pieces for tag in value.split() if tag != ""]
+        if len(tags) > 0:
+            return tags
+        else:
+            return globalTags
+
+    def processTags(self, string, note):
+        tags = [tag for tag in string.split() if tag != ""]
+        note.tags.extend(tags)
+ 
+    def processLatexField(self, string, note):
+        if string.strip() != "":
+            # string = re.sub(r"^[ \t]*", "", string, flags=re.MULTILINE)
+            # see note below
+            string = self.textToHtml(string)
+            string = r"[latex]" + string + r"[/latex]"
+        note.fields.append(string)
+        
+    def processPlainField(self, string, note):
+        string = string.strip()
+        string = re.sub(r"^[ \t]*", "", string, flags=re.MULTILINE)
+        # see note below
+        string = self.textToHtml(string)
+        note.fields.append(string)
+
+        
+### This line worked up to version 2.1.44:
+#        importing.Importers = importing.Importers + ((_("Latex Notes (*.tex)"), LatexImporter),)
+### This is the replacement suggested by Kelciour:
+def myImporters(col, _old):
+    ret = _old(col)
+    ret += ((_("Latex Notes (*.tex)"), LatexImporter),)
+    return ret
+
+importing.importers = wrap(importing.importers, myImporters, "around")
+###
+
+# note:
+# The command
+#     string = re.sub(r"^[ \t]*","",string,flags = re.MULTILINE)
+# removes all whitespace at the beginning of each line of the
+# (possibly-multiline) string.  However, I no longer understand
+# why I should do this.  In the normal Anki editor, such leading
+# whitespace does not show up in any case.  When importing
+# verbatim-environments, deleting whitespace causes problems.


### PR DESCRIPTION
- Modifies exporter to use the new exporting module which is now the default since anki 2.1.55.
- Rename all methods to use snake_case
- Extended html to latex conversion method to also convert bold, italic, underline and sub-/superscript text as well as lists to their latex equivalents.
- Removed some comments